### PR TITLE
Update Gem to Address Moneybird API Warning Responses

### DIFF
--- a/lib/moneybird/resource/contact.rb
+++ b/lib/moneybird/resource/contact.rb
@@ -7,11 +7,13 @@ module Moneybird::Resource
       address1
       address2
       administration_id
+      archived
       attention
       bank_account
       chamber_of_commerce
       city
       company_name
+      contact_people
       country
       created_at
       credit_card_number
@@ -28,6 +30,7 @@ module Moneybird::Resource
       id
       invoice_workflow_id
       lastname
+      moneybird_payments_mandate
       notes
       phone
       sales_invoices_url

--- a/lib/moneybird/resource/invoice/details.rb
+++ b/lib/moneybird/resource/invoice/details.rb
@@ -11,6 +11,7 @@ module Moneybird::Resource::Invoice
       description
       id
       ledger_account_id
+      mandatory_tax_text
       period
       price
       product_id

--- a/lib/moneybird/resource/sales_invoice.rb
+++ b/lib/moneybird/resource/sales_invoice.rb
@@ -4,10 +4,12 @@ module Moneybird::Resource
     extend Moneybird::Resource::ClassMethods
 
     has_attributes %i(
-      attachments
       administration_id
+      attachments
       contact
       contact_id
+      contact_person
+      contact_person_id
       created_at
       currency
       custom_fields
@@ -16,6 +18,7 @@ module Moneybird::Resource
       document_style_id
       draft_id
       due_date
+      events
       id
       identity_id
       invoice_date
@@ -24,7 +27,9 @@ module Moneybird::Resource
       language
       marked_dubious_on
       marked_uncollectible_on
+      next_reminder
       notes
+      original_estimate_id
       original_sales_invoice_id
       paid_at
       paused
@@ -34,9 +39,12 @@ module Moneybird::Resource
       payments
       prices_are_incl_tax
       public_view_code
+      public_view_code_expires_at
       recurring_sales_invoice_id
       reference
+      reminder_count
       sent_at
+      short_payment_reference
       state
       tax_totals
       total_discount
@@ -51,7 +59,6 @@ module Moneybird::Resource
       url
       version
       workflow_id
-      events
     )
 
     def notes=(notes)

--- a/lib/moneybird/resource/tax_rate.rb
+++ b/lib/moneybird/resource/tax_rate.rb
@@ -11,6 +11,7 @@ module Moneybird::Resource
       tax_rate_type
       show_tax
       active
+      country
       created_at
       updated_at
     )


### PR DESCRIPTION
This pull request updates the gem to address Moneybird's recent API warnings encountered during interactions.

![CleanShot 2024-05-07 at 12 43 19@2x](https://github.com/maartenvanvliet/moneybird/assets/307664/23580426-dbd7-4be9-ac72-f6d0749eb71a)

The resource classes `TaxRate`, `Contact`, `SalesInvoice`, and `Invoice::Details` were changed to add the missing attributes following the latest Moneybird API specifications to prevent warning messages.

Below are the attributes added:

- **TaxRate**: country
- **Contact**: archived, contact_people, moneybird_payments_mandate
- **SalesInvoice**: contact_person, contact_person_id, next_reminder, original_estimate_id, public_view_code_expires_at, reminder_count, short_payment_reference
- **Invoice::Details**: mandatory_tax_text

### Additional Notes
Changes should be backward compatible with previous versions of the gem (only additions, no attributes was removed)
All modifications have been tested locally to ensure functionality with the updated Moneybird API.
Further testing from other integrations is recommended to validate changes before deployment.